### PR TITLE
fixed Adjective-Object/markdown-live#19

### DIFF
--- a/client/css/markdown-document.scss
+++ b/client/css/markdown-document.scss
@@ -224,7 +224,7 @@ body {
   font-size: 16px;
   line-height: 1.6;
   word-wrap: break-word;
-  
+
   > h1, h2, h3, h4, h5, h6 {
     &:first-child {
       margin-top: 0;
@@ -492,9 +492,8 @@ p {
 }
 
 blockquote {
-  margin-top: 0;
-  margin-bottom: 16px;
   margin: 0;
+  margin-bottom: 16px;
   padding: 0 15px;
   color: $tapa_approx;
   border-left: 4px solid $alto_approx;

--- a/client/js/markdown-live.js
+++ b/client/js/markdown-live.js
@@ -32,6 +32,8 @@ const Models = {};
 const Controllers = {};
 const Views = {};
 
+let sticky = false;
+
 class Toast extends Framework {
   initialize() {
     this.elements = {
@@ -137,6 +139,13 @@ class FilesModel extends Framework {
         this.select(node._id);
       }
       else {
+        let iframeBody = document.querySelector('iframe').contentWindow.document.body;
+
+        if (existingFile.source.substr(-20) !== file.source.substr(-20) &&
+            iframeBody.scrollTop + window.innerHeight > iframeBody.offsetHeight) {
+            sticky = true;
+        }
+
         this.update(existingFile._id, file);
       }
     };
@@ -241,7 +250,7 @@ class FilesController extends Framework {
 
     // scroll to the place the old iframe was at
     const newFrame = this.element.documents.childNodes[0];
-    newFrame.contentDocument.body.scrollTop = scrollTop;
+    newFrame.contentDocument.body.scrollTop = sticky ? newFrame.contentDocument.body.offsetHeight : scrollTop;
     newFrame.contentDocument.body.scrollLeft = scrollLeft;
     this.view.hijackIframe(newFrame);
 


### PR DESCRIPTION
check if the document changed at the bottom and if the user is scrolled all the way down, if so we should be sticky at the bottom for scrollTop
